### PR TITLE
In some cases $cf['value'] may not be present.

### DIFF
--- a/include/wpml-config.php
+++ b/include/wpml-config.php
@@ -248,7 +248,8 @@ class PLL_WPML_Config {
 				if ('copy' == $cf['attributes']['action'] || (!$sync && 'translate' == $cf['attributes']['action']))
 					$metas[] = $cf['value'];
 				else
-					$metas = array_diff($metas,  array($cf['value']));
+					if (isset($cf['value']))
+						$metas = array_diff($metas,  array($cf['value']));
 			}
 		}
 		return $metas;


### PR DESCRIPTION
On some old themes $cf['value'] is not present and will throw eventually an uncontrolled exception.
